### PR TITLE
fix dependabot issue SEC-1984

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2721,9 +2721,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
     "foreground-child": {
       "version": "1.5.6",


### PR DESCRIPTION
https://mappedin.atlassian.net/browse/SEC-1984

No release will be published once this is merged, as the change is only in `package-lock.json`, which is not consumed by projects depending on this.